### PR TITLE
Check Git status before SVN

### DIFF
--- a/pad.zsh-theme
+++ b/pad.zsh-theme
@@ -94,10 +94,10 @@ function git_status {
 
 function vcs_status {
     local STATUS
-    if [[ -n "$(svn_get_branch_name)" ]]; then
-        STATUS=$(svn_status)
-    elif [[ -n "$(current_branch)" ]]; then
+    if [[ -n "$(current_branch)" ]]; then
         STATUS=$(git_status)
+    elif [[ -n "$(svn_get_branch_name)" ]]; then
+        STATUS=$(svn_status)
     fi
     [[ -n "$STATUS" ]] && echo "%{$BG[019]%} $STATUS "
 }


### PR DESCRIPTION
This disables an annoying error if there is no SVN integration. It will also speed up a bit for the majority of users who use Git primarily.